### PR TITLE
fix(serialization): Assume standard bag when seralizing

### DIFF
--- a/tests/unit/zombie_nomnom/engine/test_serialization.py
+++ b/tests/unit/zombie_nomnom/engine/test_serialization.py
@@ -84,10 +84,10 @@ def test_parse_command_dict__when_parsing_command_with_parameters_args__loads_co
     assert actual.amount_drawn == 3
 
 
-def test_format_to_json_dict__when_bag_function_is_none_and_bag_recipes_is_empty__raises_value_error():
-    with pytest.raises(ValueError):
-        game = ZombieDieGame(players=["Player Uno"])
-        format_to_json_dict(game)
+def test_format_to_json_dict__when_bag_function_is_none_and_bag_recipes_is_empty__assumes_standard_bag():
+    game = ZombieDieGame(players=["Player Uno"])
+    json = format_to_json_dict(game)
+    assert json["bag_function"] == "standard"
 
 
 def test_format_to_json_dict__when_bag_function_is_not_none_and_bag_recipes_exists__returns_valid_dict(

--- a/zombie_nomnom/engine/serialization.py
+++ b/zombie_nomnom/engine/serialization.py
@@ -109,10 +109,14 @@ def parse_command_dict(command: CommandDict) -> Command:
 
 
 def format_to_json_dict(game: ZombieDieGame) -> ZombieDieGameDict:
-    if game.bag_function is not DieBag.standard_bag and not game.bag_recipes:
-        raise ValueError(
-            "Unable to serialize custom coded bag function must either use built in standard_bag or use the bag_recipes pattern."
-        )
+    """Will default any game to be using the standard bag unless given a recipe to create dice.
+
+    **Parameters**
+    - game (`ZombieDieGame`): The game to serialize
+
+    **Returns**
+    - `ZombieDieGameDict`: The serialized game as a dict that is json serializable
+    """
     return {
         "players": [player.model_dump(mode="json") for player in game.players],
         "bag_function": (


### PR DESCRIPTION
## Describe your changes

Our check for the standard bag is broken so we will want to instead assume that any game given is using the standard bag unless we are given a recipe to change that bag.

## Issue ticket number and link

Closes #63 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have defined what tests cover my change and or added new test to cover change. 
- [x] I have added comments to the change and updated any relevant docs.
- [x] I have pulled the latest in the main branch and merged them ahead of time with no conflicts.
